### PR TITLE
Extending current ExceptionHandler in application instead of replacing it

### DIFF
--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -22,21 +22,12 @@ class ExceptionHandler implements ExceptionHandlerContract
     protected $appExceptionHandler;
 
     /**
-     * Holds an instance of the container.
-     *
-     * @var \Illuminate\Contracts\Container\Container
-     */
-    protected $container;
-
-    /**
      * Creates a new instance of the ExceptionHandler.
      *
-     * @param \Illuminate\Contracts\Container\Container $container
      * @param \Illuminate\Contracts\Debug\ExceptionHandler $appExceptionHandler
      */
-    public function __construct(Container $container, ExceptionHandlerContract $appExceptionHandler)
+    public function __construct(ExceptionHandlerContract $appExceptionHandler)
     {
-        $this->container = $container;
         $this->appExceptionHandler = $appExceptionHandler;
     }
 

--- a/src/Loggable.php
+++ b/src/Loggable.php
@@ -88,8 +88,8 @@ trait Loggable
         $appExceptionHandler = app()->make(ExceptionHandlerContract::class);
         app()->singleton(
             ExceptionHandlerContract::class,
-            function ($app) use ($appExceptionHandler) {
-                return new ExceptionHandler($app, $appExceptionHandler);
+            function () use ($appExceptionHandler) {
+                return new ExceptionHandler($appExceptionHandler);
             }
         );
         app(ExceptionHandlerContract::class)->initialize($this->icLogger);

--- a/src/Loggable.php
+++ b/src/Loggable.php
@@ -84,7 +84,14 @@ trait Loggable
 
     private function initializeErrorHandling()
     {
-        app()->singleton(ExceptionHandlerContract::class, ExceptionHandler::class);
+        // Using "Decorator" pattern
+        $appExceptionHandler = app()->make(ExceptionHandlerContract::class);
+        app()->singleton(
+            ExceptionHandlerContract::class,
+            function ($app) use ($appExceptionHandler) {
+                return new ExceptionHandler($app, $appExceptionHandler);
+            }
+        );
         app(ExceptionHandlerContract::class)->initialize($this->icLogger);
     }
 


### PR DESCRIPTION
Extending current ExceptionHandler in application instead of replacing it. After these changes the Sentry works.